### PR TITLE
#224  fix - prevent long step text to go outside container 

### DIFF
--- a/src/pages/Howto/Content/Howto/Step/elements.js
+++ b/src/pages/Howto/Content/Howto/Step/elements.js
@@ -33,6 +33,7 @@ export const StepTitle = styled(Typography)`
 
 export const StepDescription = styled(Typography)`
   margin: 20px 25px 30px !important;
+  word-wrap: break-word;
 `
 
 export const StepImage = styled.img`


### PR DESCRIPTION
* add word wrap to StepDescription style to avoid text go outside the container

@mattia-io @BenGamma 