### PR TITLE
Fix homepage navigation display

### DIFF
--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -8,6 +8,7 @@ import { UserStore } from 'src/stores/User/user.store'
 import { IStores } from 'src/stores'
 import { inject } from 'mobx-react'
 import { IUser } from 'src/models/user.models'
+import { withRouter } from 'react-router'
 
 interface IState {
   isLoggedIn: boolean
@@ -16,7 +17,7 @@ interface IState {
 @inject((allStores: IStores) => ({
   userStore: allStores.userStore,
 }))
-export class HomePage extends React.Component<IState, any> {
+class HomePageClass extends React.Component<IState, any> {
   // userUpdated is a callback function passed back up from the login container to track if the user has logged in
   // we could also use the global state for this, but for now sufficient
   public userUpdated = (user: IUser) => {
@@ -26,3 +27,5 @@ export class HomePage extends React.Component<IState, any> {
     return <div id="HomePage" />
   }
 }
+
+export const HomePage = withRouter(HomePageClass as any)

--- a/src/pages/Howto/Howto.tsx
+++ b/src/pages/Howto/Howto.tsx
@@ -17,7 +17,7 @@ interface IProps {
 // Then we can use the observer component decorator to automatically tracks observables and re-renders on change
 @observer
 class HowtoPageClass extends React.Component<IProps, any> {
-  constructor(props: any) {
+  constructor(props) {
     super(props)
   }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -23,14 +23,25 @@ export interface IPageMeta {
   component: any
   title: string
   description: string
+  exact?: boolean
 }
+
+export const HOME_PAGE: IPageMeta[] = [
+  {
+    path: '/',
+    component: <HomePage />,
+    title: 'Home',
+    description: "Welcome home, here is all the stuff you're interested in",
+    exact: true,
+  },
+]
 
 export const COMMUNITY_PAGES: IPageMeta[] = [
   {
     path: '/news',
     component: <NotFoundPage />,
     title: 'Newsfeed',
-    description: "Welcome home, here is all the stuff you're interested in",
+    description: 'Welcome to news',
   },
   {
     path: '/how-to',
@@ -113,6 +124,7 @@ export class Routes extends React.Component<any, IState> {
 
   public render() {
     const pages = [
+      ...HOME_PAGE,
       ...COMMUNITY_PAGES,
       ...COMMUNITY_PAGES_MORE,
       ...COMMUNITY_PAGES_PROFILE,
@@ -138,6 +150,7 @@ export class Routes extends React.Component<any, IState> {
               <Switch>
                 {pages.map(page => (
                   <Route
+                    exact={page.exact}
                     path={page.path}
                     key={page.path}
                     render={props => (
@@ -152,7 +165,6 @@ export class Routes extends React.Component<any, IState> {
                     )}
                   />
                 ))}
-                <Route exact path="/" component={HomePage} />
                 <Route component={NotFoundPage} />
               </Switch>
             </div>


### PR DESCRIPTION
The case when the root url was called was out of the page.map(). The Header was indeed not render with it.
I added the `/` as a proper page const `HOME_PAGE` and the boolean prop `exact` to `IPageMeta` interface.
Now if a page will need an exact path, add `exact: true` when declaring the PageMeta object. Then, all the requests for a deeper url will fallback into a 404.