### PR TITLE
Fix/73   database queries

### DIFF
--- a/src/components/Editor/common/firebase.ts
+++ b/src/components/Editor/common/firebase.ts
@@ -1,9 +1,9 @@
-import { db, storage } from 'src/utils/firebase'
+import { afs, storage } from 'src/utils/firebase'
 
 // @TODO : this is copied from other code, please extract
 
 export const storagePath = () => {
-  const databaseRef = db.collection('documentation').doc()
+  const databaseRef = afs.collection('documentation').doc()
   const docID = databaseRef.id
   return `uploads/documentation/${docID}`
 }

--- a/src/pages/Howto/Content/CreateHowto/CreateHowto.tsx
+++ b/src/pages/Howto/Content/CreateHowto/CreateHowto.tsx
@@ -4,7 +4,7 @@ import { Form, Field } from 'react-final-form'
 import { FieldArray } from 'react-final-form-arrays'
 import arrayMutators from 'final-form-arrays'
 import { IHowto, IHowtoFormInput } from 'src/models/howto.models'
-import { db } from 'src/utils/firebase'
+import { afs } from 'src/utils/firebase'
 import { TUTORIAL_TEMPLATE_DATA } from './TutorialTemplate'
 import {
   IFirebaseUploadInfo,
@@ -58,7 +58,7 @@ export class CreateHowto extends React.PureComponent<
   constructor(props: any) {
     super(props)
     // generate unique id for db and storage references and assign to state
-    const databaseRef = db.collection('documentation').doc()
+    const databaseRef = afs.collection('documentation').doc()
     const docID = databaseRef.id
     this.state = {
       formValues: { ...TUTORIAL_TEMPLATE_DATA, id: docID },
@@ -86,7 +86,7 @@ export class CreateHowto extends React.PureComponent<
         _modified: timestamp,
       }
       try {
-        await db
+        await afs
           .collection('documentation')
           .doc(formValues.id)
           .set(values)

--- a/src/pages/Howto/Content/Howto/Howto.tsx
+++ b/src/pages/Howto/Content/Howto/Howto.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { RouteComponentProps } from 'react-router'
 import LinearProgress from '@material-ui/core/LinearProgress'
-import { db } from 'src/utils/firebase'
+import { afs } from 'src/utils/firebase'
 import { inject } from 'mobx-react'
 import { HowtoStore } from 'src/stores/Howto/howto.store'
 import HowtoDescription from './HowtoDescription/HowtoDescription'
@@ -50,7 +50,7 @@ export class Howto extends React.Component<
   }
   // use firebase to query tutorials and return doc that matches the given slug
   public async getTutorialBySlug(slug: string) {
-    const ref = db
+    const ref = afs
       .collection('documentation')
       .where('slug', '==', slug)
       .limit(1)

--- a/src/stores/Events/events.store.tsx
+++ b/src/stores/Events/events.store.tsx
@@ -1,5 +1,5 @@
 import { observable, action } from 'mobx'
-import { db } from 'src/utils/firebase'
+import { afs } from 'src/utils/firebase'
 import { IEvent } from 'src/models/events.models'
 
 export class EventStore {
@@ -13,13 +13,13 @@ export class EventStore {
 
   @action
   public async getEventsList() {
-    const ref = await db.collection('events').get()
+    const ref = await afs.collection('events').get()
     this.allEvents = ref.docs.map(doc => doc.data() as IEvent)
     console.log('events retrieved', this.allEvents)
   }
 
   public async getEventBySlug(slug: string) {
-    const ref = db
+    const ref = afs
       .collection('events')
       .where('slug', '==', slug)
       .limit(1)

--- a/src/stores/Howto/howto.store.tsx
+++ b/src/stores/Howto/howto.store.tsx
@@ -1,5 +1,5 @@
 import { observable, action } from 'mobx'
-import { db } from '../../utils/firebase'
+import { afs } from '../../utils/firebase'
 import { IHowto } from 'src/models/howto.models'
 
 export class HowtoStore {
@@ -12,7 +12,7 @@ export class HowtoStore {
   // call getDocList to query 'Howtos' from db and map response to docs observable
   @action
   public async getDocList() {
-    const ref = await db
+    const ref = await afs
       .collection('documentation')
       .orderBy('_created', 'desc')
       .get()
@@ -21,7 +21,7 @@ export class HowtoStore {
   }
   @action
   public async getDocBySlug(slug: string) {
-    const ref = db
+    const ref = afs
       .collection('documentation')
       .where('slug', '==', slug)
       .limit(1)

--- a/src/stores/Tags/tags.store.tsx
+++ b/src/stores/Tags/tags.store.tsx
@@ -1,5 +1,5 @@
 import { observable, action, computed } from 'mobx'
-import { db } from '../../utils/firebase'
+import { afs } from '../../utils/firebase'
 import { TAGS_MOCK } from 'src/mocks/tags.mock'
 import { ITagQuery, ITag } from 'src/models/tags.model'
 import helpers from '../../utils/helpers'
@@ -16,7 +16,7 @@ export class TagsStore {
   // when tags are received from the database we want to populate the _key field and
   // dispatch back to the observable tags property
   public subscribeToTags() {
-    db.collection('tags').onSnapshot(snapshot => {
+    afs.collection('tags').onSnapshot(snapshot => {
       const tags: ITag[] = snapshot.docs.map(doc => {
         const data = doc.data() as ITagQuery
         const tag: ITag = { ...data, _key: doc.id }
@@ -37,10 +37,10 @@ export class TagsStore {
   // sometimes during testing we might want to put the mock data in the database
   // if so call this method
   private uploadTagsMockToDatabase() {
-    const batch = db.batch()
+    const batch = afs.batch()
     TAGS_MOCK.forEach(tag => {
       if (tag._key) {
-        const ref = db.doc(`tags/${tag._key}`)
+        const ref = afs.doc(`tags/${tag._key}`)
         batch.set(ref, tag)
       }
     })

--- a/src/stores/User/user.store.ts
+++ b/src/stores/User/user.store.ts
@@ -1,6 +1,6 @@
 import { observable, action } from 'mobx'
 import { IUser } from 'src/models/user.models'
-import { IFirebaseUser, auth, db } from 'src/utils/firebase'
+import { IFirebaseUser, auth, afs } from 'src/utils/firebase'
 
 /*
 The user store listens to login events through the firebase api and exposes logged in user information via an observer.
@@ -50,7 +50,7 @@ export class UserStore {
   }
 
   public async getUserProfile(userEmail: string) {
-    const ref = await db.doc(`users/${userEmail}`).get()
+    const ref = await afs.doc(`users/${userEmail}`).get()
     const user: IUser = ref.data() as IUser
     return user
   }

--- a/src/stores/_Template/template.store.tsx
+++ b/src/stores/_Template/template.store.tsx
@@ -1,5 +1,5 @@
 import { observable, action, computed } from 'mobx'
-import { db } from '../../utils/firebase'
+import { afs } from '../../utils/firebase'
 
 interface IExampleDoc {
   savedNumber: number
@@ -23,13 +23,13 @@ export class TemplateStore {
   // example getting a document from the main database at a given endpoint path
   @action
   public async dbDocRequest() {
-    const ref = await db.doc('_Demo/example1').get()
+    const ref = await afs.doc('_Demo/example1').get()
     this.exampleDoc = ref.data() as IExampleDoc
   }
   // example getting a collection of documents from the main database at a given endpoint path
   @action
   public async dbCollectionRequest() {
-    const ref = await db.collection('_Demo').get()
+    const ref = await afs.collection('_Demo').get()
     this.exampleCollection = ref.docs.map(doc => doc.data() as IExampleDoc)
   }
 }

--- a/src/stores/database.tsx
+++ b/src/stores/database.tsx
@@ -6,44 +6,69 @@
 
 import { Subject } from 'rxjs'
 import { afs } from 'src/utils/firebase'
-import { firestore } from 'firebase'
+import { firestore } from 'firebase/app'
 export class Database {
   // get a group of docs. returns an observable, first pulling from local cache and then searching for updates
-  static getCollection(path: string) {
+  public static getCollection(path: string) {
     const collection$ = new Subject()
     this._getCachedCollection(path).then(data => {
       // emit cached values and look for fresh
-      const cached = data.docs.map(doc => doc.data())
-      collection$.next(cached)
-      this._getLiveCollection(path, cached[0]).then(data2 => {
-        const updates = data2.docs.map(doc => doc.data())
-        collection$.next([...updates, ...cached])
+      const cached = this._preProcessData(data)
+      collection$.next([...cached].reverse())
+      this._getLiveCollection(path, cached[cached.length - 1]).then(data2 => {
+        const updates = this._preProcessData(data2)
+        // emit combination of cached and updates
+        const merged = this._mergeData(cached, updates)
+        collection$.next([...merged].reverse())
       })
     })
     return collection$
   }
 
   // get a single doc. returns an observable, first pulling from local cache and then searching for updates
-  getDoc(cacheFirst?: boolean) {}
+  public static getDoc() {}
 
-  setDoc(path: string, docValues: any) {
+  public static setDoc(path: string, docValues: any) {
     docValues._modified = new Date()
     return afs.doc(path).set(docValues)
   }
 
-  // search the persisted cache for documents and return ordered by date modified
+  // search the persisted cache for documents, return oldest to newest
   private static _getCachedCollection(path: string) {
     return afs
       .collection(path)
-      .orderBy('_modified', 'desc')
+      .orderBy('_modified', 'asc')
       .get({ source: 'cache' })
   }
-  //
-  private static _getLiveCollection(path: string, latestDoc: any) {
+  // get any documents that have been updated since last document in cache
+  // if no documents in cache fetch everything
+  private static _getLiveCollection(path: string, latestDoc?: any) {
     return afs
       .collection(path)
-      .orderBy('modified')
-      .startAfter(latestDoc)
-      .get({ source: 'cache' })
+      .orderBy('_modified', 'asc')
+      .startAfter(latestDoc ? latestDoc._modified : -1)
+      .get({ source: 'server' })
+  }
+  // when data comes in from firebase we want to preprocess, to extract the document data from firestore
+  // documents, populate a _id field (if not present) and remove deleted items
+  private static _preProcessData(data: firestore.QuerySnapshot) {
+    const docs = data.docs.map(doc => {
+      return { ...doc.data(), _id: doc.id }
+    }) as any[]
+    const filtered = docs.filter(doc => !doc._deleted)
+    return filtered
+  }
+
+  // when we have both cached and updated data retrieved, we want to merge so that any documents
+  // that have been updated don't appear in both lists
+  private static _mergeData(cached: any[], updates: any[]) {
+    const json = {}
+    cached.forEach(d => {
+      json[d._id] = d
+    })
+    updates.forEach(d => {
+      json[d._id] = d
+    })
+    return Object.values(json)
   }
 }

--- a/src/stores/database.tsx
+++ b/src/stores/database.tsx
@@ -1,0 +1,49 @@
+/*
+  This provides a go-between for stores and the database. The reason for this is
+  a) to make it easier to change database provider/model in the future
+  b) to enforce specific patterns when interacting with the database, such as setting metadata
+*/
+
+import { Subject } from 'rxjs'
+import { afs } from 'src/utils/firebase'
+import { firestore } from 'firebase'
+export class Database {
+  // get a group of docs. returns an observable, first pulling from local cache and then searching for updates
+  static getCollection(path: string) {
+    const collection$ = new Subject()
+    this._getCachedCollection(path).then(data => {
+      // emit cached values and look for fresh
+      const cached = data.docs.map(doc => doc.data())
+      collection$.next(cached)
+      this._getLiveCollection(path, cached[0]).then(data2 => {
+        const updates = data2.docs.map(doc => doc.data())
+        collection$.next([...updates, ...cached])
+      })
+    })
+    return collection$
+  }
+
+  // get a single doc. returns an observable, first pulling from local cache and then searching for updates
+  getDoc(cacheFirst?: boolean) {}
+
+  setDoc(path: string, docValues: any) {
+    docValues._modified = new Date()
+    return afs.doc(path).set(docValues)
+  }
+
+  // search the persisted cache for documents and return ordered by date modified
+  private static _getCachedCollection(path: string) {
+    return afs
+      .collection(path)
+      .orderBy('_modified', 'desc')
+      .get({ source: 'cache' })
+  }
+  //
+  private static _getLiveCollection(path: string, latestDoc: any) {
+    return afs
+      .collection(path)
+      .orderBy('modified')
+      .startAfter(latestDoc)
+      .get({ source: 'cache' })
+  }
+}

--- a/src/utils/firebase.ts
+++ b/src/utils/firebase.ts
@@ -13,7 +13,7 @@ firebase
   .catch(err => console.error('could not persist firestore', err))
 
 // export firebase endpoints to be accessed by other functions
-export const db = firebase.firestore()
+export const afs = firebase.firestore()
 export const storage = firebase.storage()
 export const auth = firebase.auth()
 export const functions = firebase.functions()

--- a/src/utils/user-migration.ts
+++ b/src/utils/user-migration.ts
@@ -1,5 +1,5 @@
 // This file handles most of the logic involved with user migration
-import { auth, db } from './firebase'
+import { auth, afs } from './firebase'
 import { ILegacyUser, IUser } from 'src/models/user.models'
 import * as phpassHasher from 'wordpress-hash-node'
 
@@ -52,7 +52,7 @@ const attemptFirebaseLogin = async (email: string, pw: string) => {
 
 const attemptLegacyMigration = async (email: string, pw: string) => {
   console.log('checking for legacy user')
-  const userDoc = await db.doc(`_legacyUsers/${email}`).get()
+  const userDoc = await afs.doc(`_legacyUsers/${email}`).get()
   if (userDoc.exists) {
     // legacy user exists, lets check the password and migrate if match
     const legacyDoc = userDoc.data() as ILegacyUser
@@ -82,7 +82,7 @@ const migrateUser = async (
 ) => {
   // populate legacy data onto user doc
   const userDoc: IUser = generateNewUserDoc(email, legacyDoc)
-  await db.doc(`users/${email}`).set(userDoc)
+  await afs.doc(`users/${email}`).set(userDoc)
   const credentials = await registerNewUser(email, pw)
   console.log('credentials received', credentials)
 }


### PR DESCRIPTION
- rename direct calls to the firebase database as `afs` instead of `db` to support new middle db layer
- initial database class with static methods to get docs and collections, first making a quick return from the local cache and then checking server for updates