### PR TITLE
351 create avatar component

### DIFF
--- a/src/components/Icons/index.tsx
+++ b/src/components/Icons/index.tsx
@@ -9,6 +9,7 @@ import {
   MdCheck,
   MdArrowBack,
   MdKeyboardArrowDown,
+  MdAccountCircle,
 } from 'react-icons/md'
 import { IconContext } from 'react-icons'
 
@@ -49,6 +50,8 @@ export const Glyph = ({ glyph }: IGlyphProps) => {
       return <MdArrowBack />
     case 'arrow-down':
       return <MdKeyboardArrowDown />
+    case 'account-circle':
+      return <MdAccountCircle />
     default:
       return null
   }

--- a/src/pages/Discussions/PostView/PostView.tsx
+++ b/src/pages/Discussions/PostView/PostView.tsx
@@ -83,7 +83,7 @@ class PostViewClass extends React.Component<IProps, IState> {
           <BoxContainer display={'inline-block'}>
             <h1>Question</h1>
             <div>{p.title}</div>
-            <Avatar />
+            <Avatar userEmail={p._createdBy} />
             <div dangerouslySetInnerHTML={{ __html: p.content }} />
           </BoxContainer>
           <h2>Responses</h2>

--- a/src/pages/Discussions/PostView/PostView.tsx
+++ b/src/pages/Discussions/PostView/PostView.tsx
@@ -10,6 +10,7 @@ import { Button } from 'src/components/Button/'
 import { PostResponse } from '../PostResponse/PostResponse'
 import PageContainer from 'src/components/Layout/PageContainer'
 import { BoxContainer } from 'src/components/Layout/BoxContainer'
+import { Avatar } from 'src/pages/common/Avatar'
 
 interface IProps extends RouteComponentProps {
   discussionsStore: DiscussionsStore
@@ -76,11 +77,13 @@ class PostViewClass extends React.Component<IProps, IState> {
   public render() {
     if (this.post) {
       const p = this.post
+
       return (
         <PageContainer>
           <BoxContainer display={'inline-block'}>
             <h1>Question</h1>
             <div>{p.title}</div>
+            <Avatar />
             <div dangerouslySetInnerHTML={{ __html: p.content }} />
           </BoxContainer>
           <h2>Responses</h2>

--- a/src/pages/common/Avatar/index.tsx
+++ b/src/pages/common/Avatar/index.tsx
@@ -1,14 +1,65 @@
 import React from 'react'
 import { Image, ImageProps } from 'rebass'
+import Icon from 'src/components/Icons'
 
-type AvatarProps = ImageProps
+import { UserStore } from 'src/stores/User/user.store'
+import { inject, observer } from 'mobx-react'
 
-export const Avatar = (props: AvatarProps) => <Image {...props} />
+interface IInjectedProps extends IProps {
+  userStore: UserStore
+}
 
-// Default styling container props
-Avatar.defaultProps = {
-  className: 'avatar',
-  width: 50,
-  borderRadius: 4,
-  src: 'http://i.pravatar.cc/200',
+interface IProps {
+  userEmail?: string
+}
+
+interface IState {
+  avatarUrl: string | null
+}
+
+type AvatarProps = ImageProps & IProps
+
+@inject('userStore')
+@observer
+export class Avatar extends React.PureComponent<AvatarProps, IState> {
+  constructor(props: any) {
+    super(props)
+    this.state = {
+      avatarUrl: null,
+    }
+  }
+  get props() {
+    return this.props as IInjectedProps
+  }
+
+  componentWillMount() {
+    this.getUserAvatar(this.props.userEmail)
+  }
+
+  public getUserAvatar = async (email: string) => {
+    try {
+      const user = await this.props.userStore.getUserProfile(email)
+      this.setState({ avatarUrl: user.avatar })
+    } catch (error) {
+      console.log('err', error)
+      throw new Error(JSON.stringify(error))
+    }
+  }
+  render() {
+    const avatarUrl = this.state.avatarUrl
+    return (
+      <>
+        {avatarUrl ? (
+          <Image
+            className="avatar"
+            width={50}
+            borderRadius={4}
+            src={avatarUrl}
+          />
+        ) : (
+          <Icon glyph={'account-circle'} />
+        )}
+      </>
+    )
+  }
 }

--- a/src/pages/common/Avatar/index.tsx
+++ b/src/pages/common/Avatar/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Image, ImageProps } from 'rebass'
+
+type AvatarProps = ImageProps
+
+export const Avatar = (props: AvatarProps) => <Image {...props} />
+
+// Default styling container props
+Avatar.defaultProps = {
+  className: 'avatar',
+  width: 50,
+  borderRadius: 4,
+  src: 'http://i.pravatar.cc/200',
+}


### PR DESCRIPTION
I created an Avatar component with the prop `userEmail`. The prop is not mandatory so if you just use the avatar component without prop, it will display a placeholder user Icon. In a close futur this placeholder should be a proper image.
As a quick solution I added an `avatar` field in the users collection in firebase with a link to our github avatar.
I added the field by hand for chris and I, there is probably a better way to do it.

TODO :
* automatically add the field for new created user.
* add the avatar to the `/profile` section with the ability to modify it
* decide where to save the avatar. To begin I think that firebase storage would be ok, but it's open for discussion