### PR TITLE
Add auth nav guards and component hide wrapper

### DIFF
--- a/src/components/Auth/AuthWrapper.tsx
+++ b/src/components/Auth/AuthWrapper.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react'
+import { inject, observer } from 'mobx-react'
+import { UserStore } from 'src/stores/User/user.store'
+
+/*
+    Simple wrapper to only render a component if the user is logged in
+*/
+
+interface IProps {
+  userStore?: UserStore
+}
+interface IState {}
+@inject('userStore')
+@observer
+export class AuthWrapper extends React.Component<IProps, IState> {
+  render() {
+    // user ! to let typescript know property will exist (injected) instead of additional getter method
+    const isAuthenticated = this.props.userStore!.user ? true : false
+    return isAuthenticated === true ? this.props.children : null
+  }
+}

--- a/src/pages/Howto/Content/HowtoList/HowtoList.tsx
+++ b/src/pages/Howto/Content/HowtoList/HowtoList.tsx
@@ -12,6 +12,7 @@ import PpLogo from 'src/assets/images/pp-icon-small.png'
 import { Button } from 'src/components/Button'
 import { IHowto } from 'src/models/howto.models'
 import { TagDisplay } from 'src/components/Tags/TagDisplay/TagDisplay'
+import { AuthWrapper } from 'src/components/Auth/AuthWrapper'
 
 interface IProps {
   allHowtos: IHowto[]
@@ -43,11 +44,13 @@ export class HowtoList extends React.Component<IProps, any> {
     return (
       <>
         <Flex justifyContent={'right'}>
-          <Link to={'/how-to/create'}>
-            <Button variant="outline" icon={'add'}>
-              create
-            </Button>
-          </Link>
+          <AuthWrapper>
+            <Link to={'/how-to/create'}>
+              <Button variant="outline" icon={'add'}>
+                create
+              </Button>
+            </Link>
+          </AuthWrapper>
         </Flex>
         <React.Fragment>
           <div>
@@ -55,8 +58,11 @@ export class HowtoList extends React.Component<IProps, any> {
               <LinearProgress />
             ) : (
               <FlexGrid flexWrap={'wrap'} justifyContent={'space-between'}>
-                {allHowtos.map((howto: IHowto, index: number) => (
-                  <Link to={`/how-to/${encodeURIComponent(howto.slug)}`}>
+                {allHowtos.map((howto: IHowto) => (
+                  <Link
+                    to={`/how-to/${encodeURIComponent(howto.slug)}`}
+                    key={howto._id}
+                  >
                     <Box my={4}>
                       <Card borderRadius={1} width={[380]} bg={'white'}>
                         <CardImage src={howto.cover_image.downloadUrl} />

--- a/src/pages/Howto/Howto.tsx
+++ b/src/pages/Howto/Howto.tsx
@@ -7,9 +7,10 @@ import { Route, Switch, withRouter, Redirect } from 'react-router-dom'
 import { Howto } from './Content/Howto/Howto'
 import { CreateHowto } from './Content/CreateHowto/CreateHowto'
 import { HowtoList } from './Content/HowtoList/HowtoList'
+import { AuthRoute } from '../common/AuthRoute'
 
 interface IProps {
-  howtoStore: HowtoStore
+  howtoStore?: HowtoStore
   nonav: boolean
 }
 
@@ -28,7 +29,7 @@ class HowtoPageClass extends React.Component<IProps, any> {
     // this will be reflected in the props.howtoStore.docs object
     // it should automatically update components however for some reason failing to
     // so call force update after first update
-    await this.props.howtoStore.getDocList()
+    await this.props.howtoStore!.getDocList()
     this.forceUpdate()
   }
 
@@ -45,11 +46,20 @@ class HowtoPageClass extends React.Component<IProps, any> {
         )}
         <Switch>
           <Route
-            exact path="/how-to"
-            render={props => <HowtoList {...props}
-            allHowtos={this.props.howtoStore.allHowtos} />}
+            exact
+            path="/how-to"
+            render={props => (
+              <HowtoList
+                {...props}
+                allHowtos={this.props.howtoStore!.allHowtos}
+              />
+            )}
           />
-          <Route path="/how-to/create" component={CreateHowto} />
+          <AuthRoute
+            path="/how-to/create"
+            component={CreateHowto}
+            redirectPath="/how-to"
+          />
           <Route path="/how-to/:slug" render={props => <Howto {...props} />} />
         </Switch>
       </div>

--- a/src/pages/common/AuthRoute.tsx
+++ b/src/pages/common/AuthRoute.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react'
+import { Route, Redirect, RouteProps } from 'react-router'
+import { inject, observer } from 'mobx-react'
+import { UserStore } from 'src/stores/User/user.store'
+
+/*
+    This provides a <AuthRoute /> component that can be used in place of <Route /> components
+    to allow user access only if authenticated. Could also be used to direct to login and back,
+    example here: https://tylermcginnis.com/react-router-protected-routes-authentication/
+*/
+
+interface IProps extends RouteProps {
+  userStore?: UserStore
+  redirectPath: string
+  component: React.ComponentClass
+}
+interface IState {}
+@inject('userStore')
+@observer
+export class AuthRoute extends React.Component<IProps, IState> {
+  static defaultProps: Partial<IProps>
+  render() {
+    // user ! to let typescript know property will exist (injected) instead of additional getter method
+    const isAuthenticated = this.props.userStore!.user ? true : false
+    const { component: Component, redirectPath, ...rest } = this.props
+    return (
+      <Route
+        {...rest}
+        render={props =>
+          isAuthenticated === true ? (
+            <Component {...props} />
+          ) : (
+            <Redirect
+              to={{
+                pathname: redirectPath,
+                state: { from: props.location },
+              }}
+            />
+          )
+        }
+      />
+    )
+  }
+}
+AuthRoute.defaultProps = {
+  redirectPath: '/',
+}


### PR DESCRIPTION
Created a new `AuthRoute` component that replaces the standard `Route` component for any routes where we only want to allow logged in users access (like how-to create). Includes an optional redirect to send the user to if not signed in

Also created a new `AuthWrapper` component that stops the render of child components if user not logged in (like the 'create how-to' button).

Have testing and working as intended so shouldn't take much review, however @BenGamma you might be interested in taking a quick look so that you can see how it's been implemented.

Closes #457 