### PR TITLE
Feat/auth role pages

### DIFF
--- a/src/components/Auth/AuthWrapper.tsx
+++ b/src/components/Auth/AuthWrapper.tsx
@@ -1,21 +1,36 @@
 import * as React from 'react'
 import { inject, observer } from 'mobx-react'
 import { UserStore } from 'src/stores/User/user.store'
+import { UserRole } from 'src/models/user.models'
 
 /*
-    Simple wrapper to only render a component if the user is logged in
+    Simple wrapper to only render a component if the user is logged in (plus optional user role required)
 */
 
 interface IProps {
   userStore?: UserStore
+  roleRequired?: UserRole
 }
 interface IState {}
 @inject('userStore')
 @observer
 export class AuthWrapper extends React.Component<IProps, IState> {
+  isUserAuthenticated() {
+    const { user } = this.props.userStore!
+    const { roleRequired } = this.props
+    if (user) {
+      if (roleRequired) {
+        return user.userRoles && user.userRoles.includes(roleRequired)
+      } else {
+        return true
+      }
+    }
+    return false
+  }
+
   render() {
     // user ! to let typescript know property will exist (injected) instead of additional getter method
-    const isAuthenticated = this.props.userStore!.user ? true : false
+    const isAuthenticated = this.isUserAuthenticated()
     return isAuthenticated === true ? this.props.children : null
   }
 }

--- a/src/models/user.models.tsx
+++ b/src/models/user.models.tsx
@@ -17,8 +17,11 @@ export interface IUser extends IDbDoc {
   // note, user avatar url is taken direct from userName so no longer populated here
   // avatar:string
   verified: boolean
+  userRoles?: UserRole[]
   about?: string
   DHSite_id?: number
   DHSite_mention_name?: string
   country?: string
 }
+
+export type UserRole = 'super-admin' | 'subscriber'

--- a/src/pages/PageList.tsx
+++ b/src/pages/PageList.tsx
@@ -6,6 +6,7 @@ import { SITE } from 'src/config/config'
 import { DiscussionsPage } from './Discussions'
 import { EventsPage } from './Events/Events'
 import { NotFoundPage } from './NotFound/NotFound'
+import { AdminPage } from './admin/Admin'
 
 export interface IPageMeta {
   path: string
@@ -51,6 +52,12 @@ const maps = {
   title: 'Maps',
   description: '',
 }
+const admin = {
+  path: '/admin',
+  component: <AdminPage />,
+  title: 'Admin',
+  description: '',
+}
 
 // community pages (various pages hidden on production build)
 const devCommunityPages = [howTo, events, discussions]
@@ -66,3 +73,4 @@ const communityPagesMore =
 export const COMMUNITY_PAGES: IPageMeta[] = communityPages
 export const COMMUNITY_PAGES_MORE: IPageMeta[] = communityPagesMore
 export const COMMUNITY_PAGES_PROFILE: IPageMeta[] = [profile, feedback]
+export const ADMIN_PAGES: IPageMeta[] = [admin]

--- a/src/pages/admin/Admin.tsx
+++ b/src/pages/admin/Admin.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react'
+
+import { withRouter, Switch, Route } from 'react-router'
+import { AuthRoute } from '../common/AuthRoute'
+import { AdminTags } from './content/AdminTags'
+import { AuthWrapper } from 'src/components/Auth/AuthWrapper'
+import { Link } from 'react-router-dom'
+import Heading from 'src/components/Heading'
+
+class AdminPageClass extends React.Component<null, null> {
+  public render() {
+    return (
+      <div id="AdminPage">
+        <Switch>
+          <Route
+            exact
+            path="/admin"
+            render={props => (
+              <AuthWrapper roleRequired="super-admin">
+                <Heading small>Super Admins Portal</Heading>
+                <Link to="/admin/tags">Tags Admin</Link>
+              </AuthWrapper>
+            )}
+          />
+          <AuthRoute
+            path="/admin/tags"
+            component={AdminTags}
+            redirectPath="/admin"
+            roleRequired="super-admin"
+          />
+        </Switch>
+      </div>
+    )
+  }
+}
+export const AdminPage = withRouter(AdminPageClass as any)

--- a/src/pages/admin/content/AdminTags.tsx
+++ b/src/pages/admin/content/AdminTags.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react'
+import { inject, observer } from 'mobx-react'
+import { TagsStore } from 'src/stores/Tags/tags.store'
+import { Button } from 'src/components/Button'
+import Heading from 'src/components/Heading'
+import Text from 'src/components/Text'
+
+// we include props from react-final-form fields so it can be used as a custom field component
+interface IProps {
+  tagsStore?: TagsStore
+}
+interface IState {
+  disabled: boolean
+  msg?: string
+}
+
+@inject('tagsStore')
+@observer
+export class AdminTags extends React.Component<IProps, IState> {
+  constructor(props: IProps) {
+    super(props)
+    this.state = {
+      disabled: false,
+    }
+  }
+
+  async uploadTags() {
+    this.setState({ disabled: true })
+    try {
+      await this.props.tagsStore!.uploadTagsMockToDatabase()
+      this.setState({ msg: 'Tags Uploaded Successfully' })
+    } catch (error) {
+      this.setState({ disabled: false, msg: 'Error: See console' })
+    }
+  }
+  public render() {
+    return (
+      <>
+        <Heading small>Tags Admin</Heading>
+        <Button
+          disabled={this.state.disabled}
+          variant={this.state.disabled ? 'disabled' : 'dark'}
+          onClick={() => this.uploadTags()}
+        >
+          Populate Tags from Mock
+        </Button>
+        <Text mt={2}>{this.state.msg}</Text>
+      </>
+    )
+  }
+}

--- a/src/pages/common/AuthRoute.tsx
+++ b/src/pages/common/AuthRoute.tsx
@@ -25,7 +25,6 @@ export class AuthRoute extends React.Component<IProps, IState> {
   isUserAuthenticated() {
     const { user } = this.props.userStore!
     const { roleRequired } = this.props
-    console.log('is user authenticated?', user, roleRequired)
     if (user) {
       if (roleRequired) {
         return user.userRoles && user.userRoles.includes(roleRequired)

--- a/src/pages/common/AuthRoute.tsx
+++ b/src/pages/common/AuthRoute.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { Route, Redirect, RouteProps } from 'react-router'
 import { inject, observer } from 'mobx-react'
 import { UserStore } from 'src/stores/User/user.store'
+import { UserRole } from 'src/models/user.models'
 
 /*
     This provides a <AuthRoute /> component that can be used in place of <Route /> components
@@ -13,15 +14,31 @@ interface IProps extends RouteProps {
   userStore?: UserStore
   redirectPath: string
   component: React.ComponentClass
+  roleRequired?: UserRole
 }
 interface IState {}
 @inject('userStore')
 @observer
 export class AuthRoute extends React.Component<IProps, IState> {
   static defaultProps: Partial<IProps>
+
+  isUserAuthenticated() {
+    const { user } = this.props.userStore!
+    const { roleRequired } = this.props
+    console.log('is user authenticated?', user, roleRequired)
+    if (user) {
+      if (roleRequired) {
+        return user.userRoles && user.userRoles.includes(roleRequired)
+      } else {
+        return true
+      }
+    }
+    return false
+  }
+
   render() {
     // user ! to let typescript know property will exist (injected) instead of additional getter method
-    const isAuthenticated = this.props.userStore!.user ? true : false
+    const isAuthenticated = this.isUserAuthenticated()
     const { component: Component, redirectPath, ...rest } = this.props
     return (
       <Route

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,6 +12,7 @@ import {
   COMMUNITY_PAGES,
   COMMUNITY_PAGES_PROFILE,
   COMMUNITY_PAGES_MORE,
+  ADMIN_PAGES,
 } from './PageList'
 
 interface IState {
@@ -29,6 +30,7 @@ export class Routes extends React.Component<any, IState> {
       ...COMMUNITY_PAGES,
       ...COMMUNITY_PAGES_PROFILE,
       ...COMMUNITY_PAGES_MORE,
+      ...ADMIN_PAGES,
     ]
     // we are rendering different pages and navigation dependent on whether the user has navigated directly to view the
     // entire site, or just one page of it via subdomains. This is so we can effectively integrate just parts of this

--- a/src/stores/Tags/tags.store.tsx
+++ b/src/stores/Tags/tags.store.tsx
@@ -26,7 +26,6 @@ export class TagsStore extends ModuleStore {
       this.allTagsByKey = arrayToJson(docs, '_id')
       this._filterTags()
     })
-    this._uploadTagsMockToDatabase()
   }
 
   private _filterTags() {
@@ -40,8 +39,8 @@ export class TagsStore extends ModuleStore {
   }
 
   // sometimes during testing we might want to put the mock data in the database
-  // if so call this method
-  private _uploadTagsMockToDatabase() {
+  // currently called from super-admin page
+  uploadTagsMockToDatabase() {
     const batch = afs.batch()
     TAGS_MOCK.forEach(tag => {
       if (tag._id) {
@@ -49,12 +48,6 @@ export class TagsStore extends ModuleStore {
         batch.set(ref, tag)
       }
     })
-    batch
-      .commit()
-      .then(
-        () => console.log('commit successful'),
-        err => console.log('commit rejected', err),
-      )
-      .catch(err => console.log('batch commit err', err))
+    return batch.commit()
   }
 }


### PR DESCRIPTION
We have 'authenticated' pages (i.e. pages only visible to logged in users, such as how-to create), but to allow more fine-grained control have added:

1) `userRoles` field to users (currently allows 'super-admin' and 'subscriber')
2) authRoute and authWrapper component additions to allow `roleRequired` to only show to users with specific role
3) Example admin page (see /admin - note blank if not super-admin)
4) Method to update tags from Mock data (once live will allow fix to #500)

for testing have added `super-admin` properties to mine and @BenGamma accounts on the dev server. Can easily add others on request. 