### PR TITLE
feat(container): pageWidth characteristics on page containers

### DIFF
--- a/src/components/Layout/PageContainer.tsx
+++ b/src/components/Layout/PageContainer.tsx
@@ -12,21 +12,28 @@ import { Flex, FlexProps } from 'rebass'
 import theme from 'src/themes/styled.theme'
 import { VersionNumber } from '../VersionNumber/VersionNumber'
 
-type InnerContainerProps = MaxWidthProps & SpaceProps & WidthProps
+type InnerContainerProps = MaxWidthProps &
+  SpaceProps &
+  WidthProps & {
+    ignoreMaxWidth?: boolean
+  }
 
 const InnerContainer = styled.div<InnerContainerProps>`
   ${space}
   ${width}
-  ${maxWidth}
+  ${p => (p.ignoreMaxWidth ? 'max-width: inherit;' : maxWidth)}
   min-height: calc(100vh - 156px);
   margin-bottom:0;
   padding-bottom: 32px;
   position: relative
 `
+interface IProps extends FlexProps {
+  ignoreMaxWidth?: boolean
+}
 
-const PageContainer = (props: FlexProps) => (
+const PageContainer = (props: IProps) => (
   <Flex {...props} bg={theme.colors.background}>
-    <InnerContainer>
+    <InnerContainer ignoreMaxWidth={props.ignoreMaxWidth}>
       {props.children} <VersionNumber />
     </InnerContainer>
   </Flex>

--- a/src/pages/PageList.tsx
+++ b/src/pages/PageList.tsx
@@ -14,6 +14,7 @@ export interface IPageMeta {
   title: string
   description: string
   exact?: boolean
+  fullPageWidth: boolean
 }
 
 const howTo = {
@@ -21,42 +22,49 @@ const howTo = {
   component: <HowtoPage />,
   title: 'How-to',
   description: 'Welcome to how-to',
+  fullPageWidth: false,
 }
 const profile = {
   path: '/profile',
   component: <ProfilePage />,
   title: 'Profile',
   description: '',
+  fullPageWidth: false,
 }
 const feedback = {
   path: '/feedback',
   component: <FeedbackPage />,
   title: 'Feedback',
   description: 'Let us know what you think!',
+  fullPageWidth: false,
 }
 const discussions = {
   path: '/discussions',
   component: <DiscussionsPage />,
   title: 'Discussions',
   description: '',
+  fullPageWidth: false,
 }
 const events = {
   path: '/events',
   component: <EventsPage />,
   title: 'Events',
   description: 'Welcome to Events',
+  fullPageWidth: false,
 }
 const maps = {
   path: '/maps',
   component: <NotFoundPage />,
   title: 'Maps',
   description: '',
+  fullPageWidth: true,
 }
 const admin = {
   path: '/admin',
   component: <AdminPage />,
   title: 'Admin',
   description: '',
+  fullPageWidth: false,
 }
 
 // community pages (various pages hidden on production build)

--- a/src/pages/PageList.tsx
+++ b/src/pages/PageList.tsx
@@ -14,7 +14,7 @@ export interface IPageMeta {
   title: string
   description: string
   exact?: boolean
-  fullPageWidth: boolean
+  fullPageWidth?: boolean
 }
 
 const howTo = {
@@ -22,35 +22,30 @@ const howTo = {
   component: <HowtoPage />,
   title: 'How-to',
   description: 'Welcome to how-to',
-  fullPageWidth: false,
 }
 const profile = {
   path: '/profile',
   component: <ProfilePage />,
   title: 'Profile',
   description: '',
-  fullPageWidth: false,
 }
 const feedback = {
   path: '/feedback',
   component: <FeedbackPage />,
   title: 'Feedback',
   description: 'Let us know what you think!',
-  fullPageWidth: false,
 }
 const discussions = {
   path: '/discussions',
   component: <DiscussionsPage />,
   title: 'Discussions',
   description: '',
-  fullPageWidth: false,
 }
 const events = {
   path: '/events',
   component: <EventsPage />,
   title: 'Events',
   description: 'Welcome to Events',
-  fullPageWidth: false,
 }
 const maps = {
   path: '/maps',
@@ -64,7 +59,6 @@ const admin = {
   component: <AdminPage />,
   title: 'Admin',
   description: '',
-  fullPageWidth: false,
 }
 
 // community pages (various pages hidden on production build)

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -65,7 +65,7 @@ export class Routes extends React.Component<any, IState> {
                           title={page.title}
                           description={page.description}
                         />
-                        <PageContainer>
+                        <PageContainer ignoreMaxWidth={page.fullPageWidth}>
                           <>{page.component}</>
                         </PageContainer>
                       </React.Fragment>


### PR DESCRIPTION
Not sure if this maps a lot of sense to do it this way, but I can imagine some pages want to have a "cover" format. I'm not sure on the right words to use, or whether you want to achieve it this way, but just an idea. The main use case is for something like Maps where you want it to cover the whole width of the page, and not be boxed into the container size.