### PR TITLE
(512) Feature: remove compression option for image upload

### DIFF
--- a/src/components/ImageInput/ImageConverter.tsx
+++ b/src/components/ImageInput/ImageConverter.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { FlexContainer } from '../Layout/FlexContainer'
 import * as clientCompress from 'client-compress'
 import { IConvertedFileMeta, bytesToSize } from './ImageInput'
 import Text from '../Text'

--- a/src/components/ImageInput/ImageConverter.tsx
+++ b/src/components/ImageInput/ImageConverter.tsx
@@ -9,6 +9,7 @@ interface IProps {
   onImgClicked: (meta: IConvertedFileMeta) => void
 }
 interface IState {
+  compressionOptions: ICompressionOptions
   convertedFile?: IConvertedFileMeta
   openLightbox?: boolean
 }
@@ -21,15 +22,15 @@ const imageSizes = {
 
 export class ImageConverter extends React.Component<IProps, IState> {
   public static defaultProps: Partial<IProps>
-  private compressionOptions = {
-    quality: 0.75,
-    maxWidth: imageSizes.low,
-  }
-  private compress: clientCompress = new clientCompress(this.compressionOptions)
 
   constructor(props: IProps) {
     super(props)
-    this.state = {}
+    this.state = {
+      compressionOptions: {
+        maxWidth: imageSizes.low,
+        quality: 0.75,
+      },
+    } as IState
   }
 
   async componentDidMount() {
@@ -45,8 +46,11 @@ export class ImageConverter extends React.Component<IProps, IState> {
   }
 
   async compressFiles(file: File) {
+    const { compressionOptions } = this.state
+    const compressor: clientCompress = new clientCompress(compressionOptions)
+
     // by default compress takes an array and gives back an array. We only want to handle a single image
-    const conversion: ICompressedOutput[] = await this.compress.compress([file])
+    const conversion: ICompressedOutput[] = await compressor.compress([file])
     const convertedMeta = this._generateFileMeta(conversion[0])
     this.setState({
       convertedFile: convertedMeta,
@@ -108,6 +112,10 @@ interface ICompressedOutput {
   info: ICompressedInfo
 }
 
+interface ICompressionOptions {
+  quality: number
+  maxWidth: number
+}
 interface ICompressedPhoto {
   name: string
   type: 'image/jpeg' | string

--- a/src/components/ImageInput/ImageConverter.tsx
+++ b/src/components/ImageInput/ImageConverter.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { FlexContainer } from '../Layout/FlexContainer'
-import { Button } from '../Button'
 import * as clientCompress from 'client-compress'
 import { IConvertedFileMeta, bytesToSize } from './ImageInput'
 import Text from '../Text'
@@ -11,12 +10,10 @@ interface IProps {
   onImgClicked: (meta: IConvertedFileMeta) => void
 }
 interface IState {
-  imageQuality: ImageQualities
   convertedFile?: IConvertedFileMeta
   openLightbox?: boolean
 }
 
-type ImageQualities = 'normal' | 'high' | 'low'
 const imageSizes = {
   low: 640,
   normal: 1280,
@@ -27,18 +24,18 @@ export class ImageConverter extends React.Component<IProps, IState> {
   public static defaultProps: Partial<IProps>
   private compressionOptions = {
     quality: 0.75,
-    maxWidth: imageSizes.normal,
+    maxWidth: imageSizes.low,
   }
   private compress: clientCompress = new clientCompress(this.compressionOptions)
 
   constructor(props: IProps) {
     super(props)
-    this.state = { imageQuality: 'normal' }
+    this.state = {}
   }
 
-  componentDidMount() {
+  async componentDidMount() {
     // call on mount to trigger initial conversion when converter created
-    this.setImageQuality('normal')
+    await this.compressFiles(this.props.file)
   }
 
   componentWillUnmount() {
@@ -46,15 +43,6 @@ export class ImageConverter extends React.Component<IProps, IState> {
     if (this.state.convertedFile) {
       URL.revokeObjectURL(this.state.convertedFile.objectUrl)
     }
-  }
-
-  async setImageQuality(quality: ImageQualities) {
-    this.setState({
-      imageQuality: quality,
-    })
-    this.compressionOptions.maxWidth = imageSizes[quality]
-    this.compress = new clientCompress(this.compressionOptions)
-    await this.compressFiles(this.props.file)
   }
 
   async compressFiles(file: File) {
@@ -81,8 +69,7 @@ export class ImageConverter extends React.Component<IProps, IState> {
   }
 
   render() {
-    const { convertedFile, imageQuality } = this.state
-    const qualities: ImageQualities[] = ['low', 'normal', 'high']
+    const { convertedFile } = this.state
 
     return convertedFile ? (
       <div>
@@ -99,18 +86,6 @@ export class ImageConverter extends React.Component<IProps, IState> {
           onClick={() => this.props.onImgClicked(convertedFile)}
         />
         <div>
-          <FlexContainer p={0} bg="none" mt={2} mb={2}>
-            {convertedFile &&
-              qualities.map(quality => (
-                <Button
-                  variant={imageQuality === quality ? 'dark' : 'outline'}
-                  key={quality}
-                  onClick={() => this.setImageQuality(quality)}
-                >
-                  {quality}
-                </Button>
-              ))}
-          </FlexContainer>
           <div>
             {convertedFile.startSize} -> {convertedFile.endSize}
           </div>

--- a/src/components/ImageInput/ImageInput.tsx
+++ b/src/components/ImageInput/ImageInput.tsx
@@ -27,10 +27,11 @@ export interface IConvertedFileMeta {
 }
 
 interface IState {
-  inputFiles: File[]
   convertedFiles: IConvertedFileMeta[]
-  openLightbox?: boolean
+  imgDelivered?: boolean
+  inputFiles: File[]
   lightboxImg?: IConvertedFileMeta
+  openLightbox?: boolean
 }
 
 export class ImageInput extends React.Component<IProps, IState> {
@@ -72,7 +73,10 @@ export class ImageInput extends React.Component<IProps, IState> {
   public handleConvertedFileChange(file: IConvertedFileMeta, index: number) {
     const { convertedFiles } = this.state
     convertedFiles[index] = file
-    this.setState({ convertedFiles })
+    this.setState(() => ({
+      convertedFiles,
+      imgDelivered: true,
+    }))
     this.triggerCallback()
   }
 
@@ -83,8 +87,14 @@ export class ImageInput extends React.Component<IProps, IState> {
     })
   }
 
+  public handleFileInput(files: FileList | null) {
+    this.setState(() => ({
+      imgDelivered: false,
+    }))
+  }
+
   render() {
-    const { inputFiles, openLightbox, lightboxImg } = this.state
+    const { inputFiles, openLightbox, lightboxImg, imgDelivered } = this.state
     // if at least one image present, hide the 'choose image' button and replace with smaller button
     const imgPreviewMode = inputFiles.length > 0
     return (
@@ -92,7 +102,8 @@ export class ImageInput extends React.Component<IProps, IState> {
         <>
           <div
             style={{
-              display: imgPreviewMode ? 'none' : 'flex',
+              opacity: imgPreviewMode ? 0 : 1, // prevent FOUC when image appears
+              display: imgDelivered ? 'none' : 'flex',
               flexDirection: 'column',
               justifyContent: 'center',
               height: '230px',
@@ -113,6 +124,7 @@ export class ImageInput extends React.Component<IProps, IState> {
               multiple={this.props.multi}
               ref={this.fileInputRef}
               style={{ display: 'none' }}
+              onChange={e => this.handleFileInput(e.target.files)}
             />
           </div>
           {inputFiles.map((file, index) => {


### PR DESCRIPTION
Resolves issue #512 by removing the option buttons for image compression, and defaults image upload to "low" setting with max width of 640. Compression rate and final file size are still shown.

Also prevent flash of unstyled content (FOUC) when loading/replacing image.