### PR TITLE
Add max-width and lightbox for images on how-to page

### DIFF
--- a/src/pages/Howto/Content/Howto/Step/ImageGallery.tsx
+++ b/src/pages/Howto/Content/Howto/Step/ImageGallery.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
-import { Box, Image, Card, Flex } from 'rebass'
+import { Image, Card, Flex } from 'rebass'
 import { IUploadedFileMeta } from 'src/stores/storage'
+import Lightbox from 'react-image-lightbox'
+import styled from 'styled-components'
 
 interface IProps {
   images: IUploadedFileMeta[]
@@ -8,12 +10,17 @@ interface IProps {
 
 interface IState {
   activeImage: IUploadedFileMeta
+  showLightbox: boolean
 }
+
+const ImageWithPointer = styled(Image)`
+  cursor: pointer;
+`
 
 export default class ImageGallery extends React.PureComponent<IProps, IState> {
   constructor(props) {
     super(props)
-    this.state = { activeImage: this.props.images[0] }
+    this.state = { activeImage: this.props.images[0], showLightbox: false }
   }
 
   setActive = image => {
@@ -22,11 +29,26 @@ export default class ImageGallery extends React.PureComponent<IProps, IState> {
     })
   }
 
+  triggerLightbox = (): void =>
+    this.setState(({ showLightbox }) => {
+      return {
+        showLightbox: !showLightbox,
+      }
+    })
+
   render() {
     let imageNumber = this.props.images.length
     return this.state.activeImage ? (
-      <Box>
-        <Image px={1} pb={4} src={this.state.activeImage.downloadUrl} />
+      <Flex flexDirection="column" alignItems="center">
+        <ImageWithPointer
+          width={[1, 1, 0.5]}
+          px={1}
+          pb={4}
+          src={this.state.activeImage.downloadUrl}
+          onClick={() => {
+            this.triggerLightbox()
+          }}
+        />
         <Flex flexWrap={'wrap'}>
           {imageNumber > 1
             ? this.props.images.map((image: any, index: number) => (
@@ -44,7 +66,14 @@ export default class ImageGallery extends React.PureComponent<IProps, IState> {
               ))
             : null}
         </Flex>
-      </Box>
+
+        {this.state.showLightbox && (
+          <Lightbox
+            mainSrc={this.state.activeImage.downloadUrl}
+            onCloseRequest={() => this.triggerLightbox()}
+          />
+        )}
+      </Flex>
     ) : null
   }
 }


### PR DESCRIPTION
I additionally added `cursor: pointer` as the Image has now an on click interaction. 